### PR TITLE
Fix null handling in get-core-content-text

### DIFF
--- a/src/utils/get-core-content-text.mjs
+++ b/src/utils/get-core-content-text.mjs
@@ -71,11 +71,13 @@ export function getCoreContentText() {
   }
 
   if (isProbablyReaderable(document)) {
-    let article = new Readability(document.cloneNode(true), {
+    const article = new Readability(document.cloneNode(true), {
       keepClasses: true,
     }).parse()
-    console.log('readerable')
-    return postProcessText(article.textContent)
+    if (article?.textContent) {
+      console.log('readerable')
+      return postProcessText(article.textContent)
+    }
   }
 
   const largestElement = findLargestElement(document.body)


### PR DESCRIPTION
## Summary
- avoid crashing if Readability parser returns null

## Testing
- `node --check src/utils/get-core-content-text.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68405a7a0bac8327b4a9ae490ca0e93c